### PR TITLE
Support non-integer days

### DIFF
--- a/types.go
+++ b/types.go
@@ -394,7 +394,7 @@ func parseFAHDuration(s string) (time.Duration, error) {
 		days = daysTemp
 
 		if dIndex >= len(shortened)-1 { // s only contains days
-			return time.Duration(float64(time.Hour) * 24 * days).Truncate(time.Second), nil
+			return time.Duration(float64(time.Hour) * 24 * days), nil
 		}
 	}
 
@@ -403,5 +403,5 @@ func parseFAHDuration(s string) (time.Duration, error) {
 		return 0, errors.WithStack(err)
 	}
 
-	return duration + time.Duration(float64(time.Hour) * 24 * days).Truncate(time.Second), nil
+	return duration + time.Duration(float64(time.Hour) * 24 * days), nil
 }

--- a/types.go
+++ b/types.go
@@ -394,7 +394,7 @@ func parseFAHDuration(s string) (time.Duration, error) {
 		days = daysTemp
 
 		if dIndex >= len(shortened)-1 { // s only contains days
-			return time.Hour * 24 * time.Duration(days), nil
+			return time.Duration(float64(time.Hour) * 24 * days).Truncate(time.Second), nil
 		}
 	}
 
@@ -403,5 +403,5 @@ func parseFAHDuration(s string) (time.Duration, error) {
 		return 0, errors.WithStack(err)
 	}
 
-	return duration + time.Hour*24*time.Duration(days), nil
+	return duration + time.Duration(float64(time.Hour) * 24 * days).Truncate(time.Second), nil
 }

--- a/types_test.go
+++ b/types_test.go
@@ -63,11 +63,6 @@ func TestParseFAHDuration(t *testing.T) {
 			time.Hour*36,
 			false,
 		},
-		{
-			"1.5 day 1 sec",
-			time.Hour*36 + time.Second,
-			false,
-		},
 	}
 
 	for i, test := range tests {

--- a/types_test.go
+++ b/types_test.go
@@ -58,6 +58,16 @@ func TestParseFAHDuration(t *testing.T) {
 			time.Hour*24 + time.Second,
 			false,
 		},
+		{
+			"1.5 days",
+			time.Hour*36,
+			false,
+		},
+		{
+			"1.5 day 1 sec",
+			time.Hour*36 + time.Second,
+			false,
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Some fields such as `eta` return non-integer days. Since `Duration` is an `int64`, the fractional part is discarded when we do `time.Duration(days)`. Doing the multiplication as `float64` fixes the issue, and truncating to seconds cleans up the output a bit.