### PR TITLE
Support uptime command

### DIFF
--- a/api.go
+++ b/api.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 )
 
 // Official FAH API documentation: https://github.com/FoldingAtHome/fah-control/wiki/3rd-party-FAHClient-API
@@ -104,6 +105,23 @@ func (a *API) NumSlots() (int, error) {
 
 	n := 0
 	return n, unmarshalPyON(s, &n)
+}
+
+// Uptime returns FAH uptime.
+func (a *API) Uptime() (time.Duration, error) {
+	// work around for response to uptime command not including a trailing newline
+	s, err := a.Exec("eval \"$(uptime)\\n\"")
+	if err != nil {
+		return 0, err
+	}
+
+	// when formatting with a newline, the response contains an extra trailing backslash
+	u, err := parseFAHDuration(strings.TrimSuffix(s, "\\"))
+	if err != nil {
+		return 0, err
+	}
+
+	return u, nil
 }
 
 // OptionsGet gets the FAH client options.

--- a/api_test.go
+++ b/api_test.go
@@ -59,6 +59,11 @@ func (a *APITestSuite) TestExec() {
 	assert.Nil(a.T(), err)
 }
 
+func (a *APITestSuite) TestExecEval() {
+	_, err := a.api.ExecEval("date")
+	assert.Nil(a.T(), err)
+}
+
 func (a *APITestSuite) TestHelp() {
 	result, err := a.api.Help()
 	assert.NotEqual(a.T(), "", result)

--- a/api_test.go
+++ b/api_test.go
@@ -75,6 +75,11 @@ func (a *APITestSuite) TestNumSlots() {
 	assert.Nil(a.T(), err)
 }
 
+func (a *APITestSuite) TestUptime() {
+	_, err := a.api.Uptime()
+	assert.Nil(a.T(), err)
+}
+
 func (a *APITestSuite) TestOptionsSetGet() {
 	if !doAllTests {
 		return


### PR DESCRIPTION
This change adds support for the `uptime` and `date` commands. Unfortunately, because the responses to these commands lack newlines, some workarounds are required. I'm pretty new to golang and am generally open to better ways to implement this.