### PR TITLE
Allow specifying telnet address

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ```
 func Example() {
-	api, err := NewAPI()
+	api, err := NewAPI(DefaultAddr)
 	if err != nil {
 		panic(err)
 	}

--- a/api.go
+++ b/api.go
@@ -29,11 +29,11 @@ type message struct {
 	err error
 }
 
-func NewAPI() (*API, error) {
-	return NewAPIWithAddress("localhost:36330")
-}
+// DefaultAddr is the default FAH telnet address.
+const DefaultAddr = ":36330"
 
-func NewAPIWithAddress(addr string) (*API, error) {
+// NewAPI connects to your FAH client. DefaultAddr is the default client address.
+func NewAPI(addr string) (*API, error) {
 	conn, err := telnet.DialTo(addr)
 	if err != nil {
 		return nil, errors.WithStack(err)

--- a/api.go
+++ b/api.go
@@ -30,7 +30,11 @@ type message struct {
 }
 
 func NewAPI() (*API, error) {
-	conn, err := telnet.DialTo("localhost:36330")
+	return NewAPIWithAddress("localhost:36330")
+}
+
+func NewAPIWithAddress(addr string) (*API, error) {
+	conn, err := telnet.DialTo(addr)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/api_test.go
+++ b/api_test.go
@@ -41,13 +41,7 @@ func TestAPITestSuite(t *testing.T) {
 }
 
 func (a *APITestSuite) SetupTest() {
-	api, err := NewAPI()
-	require.Nil(a.T(), err)
-	a.api = api
-}
-
-func (a *APITestSuite) SetupWithAddressTest() {
-	api, err := NewAPIWithAddress("localhost:36330")
+	api, err := NewAPI(DefaultAddr)
 	require.Nil(a.T(), err)
 	a.api = api
 }

--- a/api_test.go
+++ b/api_test.go
@@ -46,6 +46,12 @@ func (a *APITestSuite) SetupTest() {
 	a.api = api
 }
 
+func (a *APITestSuite) SetupWithAddressTest() {
+	api, err := NewAPIWithAddress("localhost:36330")
+	require.Nil(a.T(), err)
+	a.api = api
+}
+
 func (a *APITestSuite) TestAPI() {
 	// For trying new commands
 	s, err := a.api.Exec("")

--- a/example_test.go
+++ b/example_test.go
@@ -1,7 +1,7 @@
 package fahapi
 
 func Example() {
-	api, err := NewAPI()
+	api, err := NewAPI(DefaultAddr)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This change adds an alternate version of `NewAPI` called `NewAPIWithAddress` that allows specifying the address of the FAHClient telnet API.